### PR TITLE
 Version tags removed for dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [0.1.0] - 2018-08-02
+### Changed
+- Removed version tags to dependencies and updated to latest versions
+### Fixed
+- deprecated rspec .should method (using expect().to eq now)

--- a/lib/office_autopilot/version.rb
+++ b/lib/office_autopilot/version.rb
@@ -1,3 +1,3 @@
 module OfficeAutopilot
-  VERSION = "0.0.4"
+  VERSION = "0.1.0"
 end

--- a/office_autopilot.gemspec
+++ b/office_autopilot.gemspec
@@ -4,13 +4,13 @@ require "office_autopilot/version"
 
 Gem::Specification.new do |s|
 
-  s.add_development_dependency('rake', '~> 0.8')
-  s.add_development_dependency('rspec', '~> 2.5')
-  s.add_development_dependency('webmock', '~> 1.6')
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'webmock'
 
-  s.add_runtime_dependency('httparty', '~> 0.7')
-  s.add_runtime_dependency('builder', '>= 2.1.2')
-  s.add_runtime_dependency('nokogiri', '~> 1.4')
+  s.add_runtime_dependency 'httparty'
+  s.add_runtime_dependency 'builder'
+  s.add_runtime_dependency 'nokogiri'
 
   s.name        = "office_autopilot"
   s.version     = OfficeAutopilot::VERSION

--- a/spec/office_autopilot/client/contacts_spec.rb
+++ b/spec/office_autopilot/client/contacts_spec.rb
@@ -37,9 +37,9 @@ describe OfficeAutopilot::Client::Contacts do
         value = "john@example.com"
 
         xml = Nokogiri::XML(@client.send(:xml_for_search, { :field => field, :op => op, :value => value }) )
-        xml.at_css('field').content.should == field
-        xml.at_css('op').content.should == op
-        xml.at_css('value').content.should == value
+        expect(xml.at_css('field').content).to eq field
+        expect(xml.at_css('op').content).to eq op
+        expect(xml.at_css('value').content).to eq value
       end
     end
 
@@ -52,13 +52,13 @@ describe OfficeAutopilot::Client::Contacts do
 
         xml = @client.send(:xml_for_search, search_options)
         xml = Nokogiri::XML(xml)
-        xml.css('field')[0].content.should == 'E-Mail'
-        xml.css('op')[0].content.should == 'e'
-        xml.css('value')[0].content.should == 'foo@example.com'
+        expect(xml.css('field')[0].content).to eq 'E-Mail'
+        expect(xml.css('op')[0].content).to eq 'e'
+        expect(xml.css('value')[0].content).to eq 'foo@example.com'
 
-        xml.css('field')[1].content.should == 'Contact Tags'
-        xml.css('op')[1].content.should == 'n'
-        xml.css('value')[1].content.should == 'bar'
+        expect(xml.css('field')[1].content).to eq 'Contact Tags'
+        expect(xml.css('op')[1].content).to eq 'n'
+        expect(xml.css('value')[1].content).to eq 'bar'
       end
     end
   end
@@ -73,8 +73,8 @@ describe OfficeAutopilot::Client::Contacts do
       stub_request(:post, @contact_endpoint).with(:body => request_body).to_return(:body => contacts_xml)
 
       contacts = @client.contacts_search(search_options)
-      WebMock.should have_requested(:post, @contact_endpoint).with(:body => request_body)
-      contacts.should == @client.send(:parse_contacts_xml, contacts_xml)
+      expect(WebMock).to have_requested(:post, @contact_endpoint).with(:body => request_body)
+      expect(contacts).to eq @client.send(:parse_contacts_xml, contacts_xml)
     end
   end
 
@@ -90,14 +90,14 @@ describe OfficeAutopilot::Client::Contacts do
       xml = @client.send(:xml_for_contact, @contact_options)
       xml = Nokogiri::XML(xml)
 
-      xml.at_css('contact')['id'].should be_nil
+      expect(xml.at_css('contact')['id']).to be_nil
 
       contact_info = xml.css("contact Group_Tag[name='Contact Information']")
-      contact_info.at_css("field[name='First Name']").content.should == 'Bob'
-      contact_info.at_css("field[name='Last Name']").content.should == 'Foo'
+      expect(contact_info.at_css("field[name='First Name']").content).to eq 'Bob'
+      expect(contact_info.at_css("field[name='Last Name']").content).to eq 'Foo'
 
       lead_info = xml.css("contact Group_Tag[name='Lead Information']")
-      lead_info.at_css("field[name='Contact Owner']").content.should == 'Mr Bar'
+      expect(lead_info.at_css("field[name='Contact Owner']").content).to eq 'Mr Bar'
     end
 
     context "when 'id' is specified" do
@@ -105,13 +105,13 @@ describe OfficeAutopilot::Client::Contacts do
         @contact_options.merge!('id' => '1234')
         xml = Nokogiri::XML( @client.send(:xml_for_contact, @contact_options) )
 
-        xml.at_css('contact')['id'].should == '1234'
+        expect(xml.at_css('contact')['id']).to eq '1234'
         contact_info = xml.css("contact Group_Tag[name='Contact Information']")
-        contact_info.at_css("field[name='First Name']").content.should == 'Bob'
-        contact_info.at_css("field[name='Last Name']").content.should == 'Foo'
+        expect(contact_info.at_css("field[name='First Name']").content).to eq 'Bob'
+        expect(contact_info.at_css("field[name='Last Name']").content).to eq 'Foo'
 
         lead_info = xml.css("contact Group_Tag[name='Lead Information']")
-        lead_info.at_css("field[name='Contact Owner']").content.should == 'Mr Bar'
+        expect(lead_info.at_css("field[name='Contact Owner']").content).to eq 'Mr Bar'
       end
     end
   end
@@ -121,14 +121,14 @@ describe OfficeAutopilot::Client::Contacts do
       it "returns an array containing the contact" do
         contacts = @client.send(:parse_contacts_xml, test_data('contacts_search_single_response.xml'))
 
-        contacts.size.should == 1
+        expect(contacts.size).to eq 1
 
         contacts.each do |contact|
-          contact['id'].should == '7'
-          contact['Contact Information']['First Name'].should == 'prashant'
-          contact['Contact Information']['Last Name'].should == 'nadarajan'
-          contact['Contact Information']['E-Mail'].should == 'prashant@example.com'
-          contact['Lead Information']['Contact Owner'].should == 'Don Corleone'
+          expect(contact['id']).to eq '7'
+          expect(contact['Contact Information']['First Name']).to eq 'prashant'
+          expect(contact['Contact Information']['Last Name']).to eq 'nadarajan'
+          expect(contact['Contact Information']['E-Mail']).to eq 'prashant@example.com'
+          expect(contact['Lead Information']['Contact Owner']).to eq 'Don Corleone'
         end
       end
     end
@@ -137,15 +137,15 @@ describe OfficeAutopilot::Client::Contacts do
       it "returns an array containing the contacts" do
         contacts = @client.send(:parse_contacts_xml, test_data('contacts_search_multiple_response.xml'))
 
-        contacts.size.should == 3
+        expect(contacts.size).to eq 3
 
-        contacts[0]['id'].should == '8'
-        contacts[0]['Contact Information']['E-Mail'].should == 'bobby@example.com'
-        contacts[0]['Lead Information']['Contact Owner'].should == 'Jimbo Watunusi'
+        expect(contacts[0]['id']).to eq '8'
+        expect(contacts[0]['Contact Information']['E-Mail']).to eq 'bobby@example.com'
+        expect(contacts[0]['Lead Information']['Contact Owner']).to eq 'Jimbo Watunusi'
 
-        contacts[1]['id'].should == '5'
-        contacts[1]['Contact Information']['E-Mail'].should == 'ali@example.com'
-        contacts[1]['Lead Information']['Contact Owner'].should == 'Jimbo Watunusi'
+        expect(contacts[1]['id']).to eq '5'
+        expect(contacts[1]['Contact Information']['E-Mail']).to eq 'ali@example.com'
+        expect(contacts[1]['Lead Information']['Contact Owner']).to eq 'Jimbo Watunusi'
       end
     end
   end
@@ -164,13 +164,13 @@ describe OfficeAutopilot::Client::Contacts do
       stub_request(:post, @contact_endpoint).with(:body => request_body).to_return(:body => response_contact_xml)
 
       contact = @client.contacts_add(contact_options)
-      WebMock.should have_requested(:post, @contact_endpoint).with(:body => request_body)
+      expect(WebMock).to have_requested(:post, @contact_endpoint).with(:body => request_body)
 
-      contact['id'].should == '7'
-      contact['Contact Information']['First Name'].should == 'prashant'
-      contact['Contact Information']['Last Name'].should == 'nadarajan'
-      contact['Contact Information']['E-Mail'].should == 'prashant@example.com'
-      contact['Lead Information']['Contact Owner'].should == 'Don Corleone'
+      expect(contact['id']).to eq '7'
+      expect(contact['Contact Information']['First Name']).to eq 'prashant'
+      expect(contact['Contact Information']['Last Name']).to eq 'nadarajan'
+      expect(contact['Contact Information']['E-Mail']).to eq 'prashant@example.com'
+      expect(contact['Lead Information']['Contact Owner']).to eq 'Don Corleone'
     end
   end
 
@@ -180,9 +180,9 @@ describe OfficeAutopilot::Client::Contacts do
       stub_request(:post, @contact_endpoint).with(:body => request_body('pull_tag')).to_return(:body => pull_tags_xml)
 
       tags = @client.contacts_pull_tag
-      tags['3'].should == 'newleads'
-      tags['4'].should == 'old_leads'
-      tags['5'].should == 'legacy Leads'
+      expect(tags['3']).to eq 'newleads'
+      expect(tags['4']).to eq 'old_leads'
+      expect(tags['5']).to eq 'legacy Leads'
     end
   end
 
@@ -191,8 +191,8 @@ describe OfficeAutopilot::Client::Contacts do
       xml = test_data('contacts_fetch_sequences.xml')
       stub_request(:post, @contact_endpoint).with(:body => request_body('fetch_sequences')).to_return(:body => xml)
       sequences = @client.contacts_fetch_sequences
-      sequences['3'].should == 'APPOINTMENT REMINDER'
-      sequences['4'].should == 'foo sequence'
+      expect(sequences['3']).to eq 'APPOINTMENT REMINDER'
+      expect(sequences['4']).to eq 'foo sequence'
     end
   end
 
@@ -202,20 +202,20 @@ describe OfficeAutopilot::Client::Contacts do
       stub_request(:post, @contact_endpoint).with(:body => request_body('key')).to_return(:body => xml)
 
       result = @client.contacts_key
-      result["Contact Information"]["editable"].should be_false
-      result["Contact Information"]["fields"]["Cell Phone"]["editable"].should be_false
-      result["Contact Information"]["fields"]["Cell Phone"]["type"].should == "phone"
-      result["Contact Information"]["fields"]["Birthday"]["type"].should == "fulldate"
+      expect(result["Contact Information"]["editable"]).to be_falsey
+      expect(result["Contact Information"]["fields"]["Cell Phone"]["editable"]).to be_falsey
+      expect(result["Contact Information"]["fields"]["Cell Phone"]["type"]).to eq "phone"
+      expect(result["Contact Information"]["fields"]["Birthday"]["type"]).to eq "fulldate"
 
-      result["Lead Information"]["fields"]["Lead Source"]["type"].should == "tdrop"
-      result["Lead Information"]["fields"]["Lead Source"]["options"][0].should == "Adwords"
-      result["Lead Information"]["fields"]["Lead Source"]["options"][4].should == "Newspaper Ad"
+      expect(result["Lead Information"]["fields"]["Lead Source"]["type"]).to eq "tdrop"
+      expect(result["Lead Information"]["fields"]["Lead Source"]["options"][0]).to eq "Adwords"
+      expect(result["Lead Information"]["fields"]["Lead Source"]["options"][4]).to eq "Newspaper Ad"
 
-      result["Sequences and Tags"]["fields"]["Contact Tags"]["type"].should == "list"
-      result["Sequences and Tags"]["fields"]["Contact Tags"]["list"]["5"].should == "legacy Leads"
+      expect(result["Sequences and Tags"]["fields"]["Contact Tags"]["type"]).to eq "list"
+      expect(result["Sequences and Tags"]["fields"]["Contact Tags"]["list"]["5"]).to eq "legacy Leads"
 
-      result["PrecisoPro"]["editable"].should be_true
-      result["PrecisoPro"]["fields"]["Lead Status"]["editable"].should be_true
+      expect(result["PrecisoPro"]["editable"]).to be_truthy
+      expect(result["PrecisoPro"]["fields"]["Lead Status"]["editable"]).to be_truthy
     end
   end
 
@@ -227,8 +227,8 @@ describe OfficeAutopilot::Client::Contacts do
         stub_request(:post, @contact_endpoint).with(:body => request_body('fetch', 'data' => xml_request )).to_return(:body => xml_response)
 
         results = @client.contacts_fetch([8, 5, 7])
-        results.size.should == 3
-        results[0]["Contact Information"].should_not be_nil
+        expect(results.size).to eq 3
+        expect(results[0]["Contact Information"]).not_to be_nil
       end
     end
 

--- a/spec/office_autopilot/client_spec.rb
+++ b/spec/office_autopilot/client_spec.rb
@@ -10,9 +10,9 @@ describe OfficeAutopilot::Client do
 
   describe "#new" do
     it "initializes with the given API credentials" do
-      @client.api_id.should == @api_id
-      @client.api_key.should == @api_key
-      @client.auth.should == { 'Appid' => @api_id, 'Key' => @api_key }
+      expect(@client.api_id).to eq @api_id
+      expect(@client.api_key).to eq @api_key
+      expect(@client.auth).to eq({ 'Appid' => @api_id, 'Key' => @api_key })
     end
 
     it "raises an ArgumentError when :api_id is not provided" do
@@ -29,8 +29,17 @@ describe OfficeAutopilot::Client do
   end
 
   describe "#request" do
+    let(:path) { 'path' }
+    let(:options) { { body: { key: 'value' } } }
+    response = '<result>Success</result>'
+
+    before do
+      allow(OfficeAutopilot::Request).to receive(:contact).with(path, options)
+        .and_return(response)
+    end
+
     it "makes a HTTP request" do
-       pending "can't seem to stub out OfficeAutopilot::Request.post"
+      expect(@client.request(:contact, path, options)).to eq response
     end
   end
 
@@ -38,7 +47,7 @@ describe OfficeAutopilot::Client do
     context "when there are no errors" do
       it "returns the response verbatim" do
         response = '<result>Success</result>'
-        @client.handle_response(response).should == response
+        expect(@client.handle_response(response)).to eq response
       end
     end
 

--- a/spec/office_autopilot/request_spec.rb
+++ b/spec/office_autopilot/request_spec.rb
@@ -4,11 +4,11 @@ describe OfficeAutopilot::Request do
 
   describe "HTTParty" do
     it "sets the base uri to the Office Autopilot API host" do
-      OfficeAutopilot::Request.base_uri.should == 'http://api.moon-ray.com'
+      expect(OfficeAutopilot::Request.base_uri).to eq 'http://api.moon-ray.com'
     end
 
     it "set the format to :plain" do
-      OfficeAutopilot::Request.format.should == :plain
+      expect(OfficeAutopilot::Request.format).to eq :plain
     end
   end
 


### PR DESCRIPTION
Having version tags here could be annoying so we can define the version of the gems directly in the main rails app without updating this repo. 
Make sense?